### PR TITLE
Add specifications for Classic Peripherals radio tower 

### DIFF
--- a/tower.md
+++ b/tower.md
@@ -15,6 +15,6 @@ string.pack(
 Receivers MUST listen on port 9773 for ShopSync packets
 Receivers MUST accept packed data containing:
 1. A serialized JSON ShopSync packet
-2 A SHA-256 hash of that packet
+2. A SHA-256 hash of that packet
 The receiver then MUST verify that the SHA-256 hash matches the serialized packet.
 Receivers MUST reject the packet if the SHA-256 hash is invalid or missing.

--- a/tower.md
+++ b/tower.md
@@ -1,0 +1,20 @@
+## Shopsync over Classic Peripherals radio towers
+## Shops
+Shops MUST transmit ShopSync data as two packed strings using the "ss" format, transmitted over port 9773:
+1. The serialized JSON ShopSync packet
+2. The SHA-256 hash of the serialized packet
+Example:
+string.pack(
+  "ss",
+  textutils.serializeJSON(packet),
+  sha256(textutils.serializeJSON(packet))
+)
+
+
+## Receivers
+Receivers MUST listen on port 9773 for ShopSync packets
+Receivers MUST accept packed data containing:
+1. A serialized JSON ShopSync packet
+2 A SHA-256 hash of that packet
+The receiver then MUST verify that the SHA-256 hash matches the serialized packet.
+Receivers MUST reject the packet if the SHA-256 hash is invalid or missing.

--- a/tower.md
+++ b/tower.md
@@ -1,8 +1,8 @@
 ## Shopsync over Classic Peripherals radio towers
 ## Shops
 Shops MUST transmit ShopSync data as two packed strings using the "ss" format, transmitted over port 9773:
-1. The serialized JSON ShopSync packet
-2. The SHA-256 hash of the serialized packet
+1. The serialized JSON ShopSync packet.
+2. The SHA-256 hash of the serialized packet.
 Example:
 string.pack(
   "ss",

--- a/tower.md
+++ b/tower.md
@@ -3,6 +3,7 @@
 Shops MUST transmit ShopSync data as two packed strings using the "ss" format, transmitted over port 9773:
 1. The serialized JSON ShopSync packet.
 2. The SHA-256 hash of the serialized packet.
+
 Example:
 ```lua
 string.pack(
@@ -16,5 +17,6 @@ Receivers MUST listen on port 9773 for ShopSync packets
 Receivers MUST accept packed data containing:
 1. A serialized JSON ShopSync packet.
 2. A SHA-256 hash of that packet.
+
 The receiver then MUST verify that the SHA-256 hash matches the serialized packet.
 Receivers MUST reject the packet if the SHA-256 hash is invalid or missing.

--- a/tower.md
+++ b/tower.md
@@ -4,17 +4,17 @@ Shops MUST transmit ShopSync data as two packed strings using the "ss" format, t
 1. The serialized JSON ShopSync packet.
 2. The SHA-256 hash of the serialized packet.
 Example:
+```lua
 string.pack(
   "ss",
   textutils.serializeJSON(packet),
   sha256(textutils.serializeJSON(packet))
 )
-
-
+```
 ## Receivers
 Receivers MUST listen on port 9773 for ShopSync packets
 Receivers MUST accept packed data containing:
-1. A serialized JSON ShopSync packet
-2. A SHA-256 hash of that packet
+1. A serialized JSON ShopSync packet.
+2. A SHA-256 hash of that packet.
 The receiver then MUST verify that the SHA-256 hash matches the serialized packet.
 Receivers MUST reject the packet if the SHA-256 hash is invalid or missing.


### PR DESCRIPTION
Adds specifications for the Classic Peripherals radio tower in order to ensure the received packet is not corrupted.